### PR TITLE
Update Rust version & set edition 2021

### DIFF
--- a/discord/dockerfiles/rs-Dockerfile
+++ b/discord/dockerfiles/rs-Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.50.0-alpine3.12
+FROM rust:1.58.1-alpine3.14
 
 ARG MESSAGE_ID
 
@@ -11,4 +11,4 @@ COPY ./playground/$MESSAGE_ID.rs ./main.rs
 RUN chown -R execbot:execbot ./
 USER execbot
 
-ENTRYPOINT rustc main.rs && ./main
+ENTRYPOINT rustc --edition 2021 main.rs && ./main


### PR DESCRIPTION
Updated the Rust Dockerfile to the latest version of Rust, and explicitly selected Edition 2021 in the command-line arguments.