### PR TITLE
Fix main function declaration searching bug

### DIFF
--- a/discord/code_processing.py
+++ b/discord/code_processing.py
@@ -21,7 +21,7 @@ int main() {{
   {}
 }}""",
         "go": """package main
-        
+
 import (
   "fmt"
   "math"
@@ -41,10 +41,10 @@ func main() {{
     }
 
     regexes = {
-        "cpp": "(?:int|void) main(?:\s*)\(.*\)",
-        "c": "(?:int|void) main(?:\s*)\(.*\)",
-        "go": "func main(?:\s*)\(.*\)",
-        "rs": "fn main(?:\s*)\(.*\)"
+        "cpp": "(?:int|void) main(?:\\s*)\\(.*\\)",
+        "c": "(?:int|void) main(?:\\s*)\\(.*\\)",
+        "go": "func main(?:\\s*)\\(.*\\)",
+        "rs": "fn main(?:\\s*)\\(.*\\)"
     }
 
     try:

--- a/discord/code_processing.py
+++ b/discord/code_processing.py
@@ -21,7 +21,7 @@ int main() {{
   {}
 }}""",
         "go": """package main
-
+        
 import (
   "fmt"
   "math"
@@ -41,10 +41,10 @@ func main() {{
     }
 
     regexes = {
-        "cpp": "(?:int|void) main(?:\\s*)\\(.*\\)",
-        "c": "(?:int|void) main(?:\\s*)\\(.*\\)",
-        "go": "func main(?:\\s*)\\(.*\\)",
-        "rs": "fn main(?:\\s*)\\(.*\\)"
+        "cpp": "(?:int|void) main(?:\s*)\(.*\)",
+        "c": "(?:int|void) main(?:\s*)\(.*\)",
+        "go": "func main(?:\s*)\(.*\)",
+        "rs": "fn main(?:\s*)\(.*\)"
     }
 
     try:

--- a/discord/code_processing.py
+++ b/discord/code_processing.py
@@ -53,9 +53,9 @@ func main() {{
     except KeyError:
         return code
 
-    r = re.compile(regex)
+    r = re.compile(regex, re.IGNORECASE)
 
-    if r.search(code, re.IGNORECASE):
+    if r.search(code):
         return code
     else:
         return default.format(code)


### PR DESCRIPTION
This PR fixes the problem that happened in https://discord.com/channels/573576119819829249/612329169011081219/948283184171323475, i.e., failing to detect a `main` function declaration when the declaration occurs within the first 2 characters of the source code. This was caused by the fact that the second argument to `pattern.search` is the first index to start searching from (not the search options), and the constant `re.IGNORECASE` is coerced to the integer 2.