### PR TITLE
Add Java support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ launcher.sh
 __pycache__/
 discord/__pycache__
 processing
+discord/playground/*

--- a/discord/code_processing.py
+++ b/discord/code_processing.py
@@ -37,14 +37,24 @@ func main() {{
 }}""",
         "rs": """fn main() {{
     {}
-}}"""
+}}""",
+        "java": """import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class Main {
+        public static void main(String[] args) {{
+            {}
+        }}
+}"""
     }
 
     regexes = {
         "cpp": "(?:int|void) main(?:\s*)\(.*\)",
         "c": "(?:int|void) main(?:\s*)\(.*\)",
         "go": "func main(?:\s*)\(.*\)",
-        "rs": "fn main(?:\s*)\(.*\)"
+        "rs": "fn main(?:\s*)\(.*\)",
+        "java": "public static void main(?:\s*)\(.*\)"
     }
 
     try:
@@ -56,6 +66,13 @@ func main() {{
     r = re.compile(regex, re.IGNORECASE)
 
     if r.search(code):
+        # if we're using java...
+        if (lang == "java"):
+            # change the class name to Main
+            code = re.sub("(?<=(public class ))(([A-Z]|[a-z])*)", "Main", code, count=1)
+            # and remove any package declaration
+            code = re.sub("package (.*)", "", code, count=1)
+        
         return code
     else:
         return default.format(code)

--- a/discord/code_processing.py
+++ b/discord/code_processing.py
@@ -42,11 +42,11 @@ func main() {{
 import java.util.*;
 import java.util.concurrent.*;
 
-public class Main {
+public class Main {{
         public static void main(String[] args) {{
             {}
         }}
-}"""
+}}"""
     }
 
     regexes = {

--- a/discord/dockerfiles/java-Dockerfile
+++ b/discord/dockerfiles/java-Dockerfile
@@ -2,13 +2,13 @@ FROM openjdk:17
 
 ARG MESSAGE_ID
 
-RUN adduser -D execbot
+# RUN useradd -D -m execbot
 
 WORKDIR /usr/src/app
 
 COPY ./playground/$MESSAGE_ID.java ./Main.java
 
-RUN chown -R execbot:execbot ./
-USER execbot
+# RUN chown -R execbot:execbot ./
+# USER execbot
 
 ENTRYPOINT javac Main.java && java Main

--- a/discord/dockerfiles/java-Dockerfile
+++ b/discord/dockerfiles/java-Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:17
+
+ARG MESSAGE_ID
+
+RUN adduser -D execbot
+
+WORKDIR /usr/src/app
+
+COPY ./playground/$MESSAGE_ID.java ./Main.java
+
+RUN chown -R execbot:execbot ./
+USER execbot
+
+ENTRYPOINT javac Main.java && java Main

--- a/discord/dockerfiles/java-Dockerfile
+++ b/discord/dockerfiles/java-Dockerfile
@@ -2,13 +2,13 @@ FROM openjdk:17
 
 ARG MESSAGE_ID
 
-# RUN useradd -D -m execbot
+RUN useradd -m execbot
 
 WORKDIR /usr/src/app
 
 COPY ./playground/$MESSAGE_ID.java ./Main.java
 
-# RUN chown -R execbot:execbot ./
-# USER execbot
+RUN chown -R execbot:execbot ./
+USER execbot
 
 ENTRYPOINT javac Main.java && java Main

--- a/discord/help.py
+++ b/discord/help.py
@@ -13,10 +13,11 @@ class Help(commands.Cog):
         self.bash = "<:bash:831116845133332500>"
         self.js = "<:nodejs:834358450309300265>"
         self.cpp = "<:cpp:917582153544507442>"
+        self.java = "java" # TODO: get me a java discord emoji
 
     @commands.command(name="help")
     async def _help(self, ctx):
-        langs = "{}, {}, {}, {}, {}, {}, and {}".format(self.python, self.go, self.c, self.rust, self.bash, self.js, self.cpp)
+        langs = "{}, {}, {}, {}, {}, {}, {}, and {}".format(self.python, self.go, self.java, self.c, self.rust, self.bash, self.js, self.cpp)
         description = """exec runs code snippets straight from Discord. Each snippet is completely isolated in its own container and runs for a maximum of 45 seconds.
 
 To run a snippet, type `execute ` (note the space) followed by a [syntax-highlighted code block](https://gist.github.com/matthewzring/9f7bbfd102003963f9be7dbcf7d40e51#syntax-highlighting) (e.g. Python is ` ```py`). After the code inside the block finishes running, the entire `.log` file will be posted.

--- a/discord/playground.py
+++ b/discord/playground.py
@@ -46,7 +46,8 @@ class Playground(commands.Cog):
                             "bash": "<:bash:831116845133332500>",
                             "zsh": "<:bash:831116845133332500>",
                             "js": "<:nodejs:834358450309300265>",
-                            "cpp": "<:cpp:917582153544507442>"}
+                            "cpp": "<:cpp:917582153544507442>",
+                            "java": "java"}
 
     async def log(self, message_id, language):
         """Store the message ID and language in the database for statistical purposes"""
@@ -118,7 +119,8 @@ class Playground(commands.Cog):
                                             buildargs={"MESSAGE_ID": str(ctx.message.id)},
                                             tag="execbot/" + str(ctx.message.id),
                                             forcerm=True)
-        except docker.errors.BuildError:
+        except docker.errors.BuildError as e:
+            self.logger.error(repr(e))
             await ctx.message.remove_reaction("⏳", ctx.me)
             await ctx.message.add_reaction("❌")
             await ctx.reply("Your snippet failed to compile. Please double-check syntax and try again.")

--- a/discord/playground.py
+++ b/discord/playground.py
@@ -76,7 +76,8 @@ class Playground(commands.Cog):
                     "```(?:bash|sh)([\s\S]*?)```",
                     "```(?:zsh)([\s\S]*?)```",
                     "```(?:rust|rs)([\s\S]*?)```",
-                    "```(?:javascript|js)([\s\S]*?)```"]
+                    "```(?:javascript|js)([\s\S]*?)```",
+                    "```(?:java)([\s\S]*?)```"]
         langs = ["py",
                     "cpp",
                     "c",
@@ -84,7 +85,8 @@ class Playground(commands.Cog):
                     "bash",
                     "zsh",
                     "rs",
-                    "js"]
+                    "js",
+                    "java"]
         i = 0
         while i < len(regexes):
             r = re.compile(regexes[i])

--- a/launcher.template.sh
+++ b/launcher.template.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 export EXECBOT_DISCORD_TOKEN=""
-export EXECBOT_ENV_TYPE=""
+export EXECBOT_ENV_TYPE="MASTER"
 export EXECBOT_LOGGING_WEBHOOK=""
 
-python main.py
+mkdir -p discord/playground
+
+cd discord && python main.py


### PR DESCRIPTION
Add Java support for both full-file & snippet functionality.

One thing worth looking at is the fact that I added some extra regex parsing for Java specifically, as the compiler is very particular about how classes should be formatted. I figured that would be the better option as it would allow users to just Ctrl+C Ctrl+V from their IDE into Discord, but let me know if you want me to remove that before merging and I will.